### PR TITLE
Accept messages without trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ Install-Package WCFDistributedTracing
 ```csharp
 var host = new TracingEnabledServiceHost(typeof(SimpleEdgeService), new Uri(SimpleEdgeService.BaseAddress));
 var endPoint = host.AddServiceEndpoint(typeof(ISimpleEdgeService), new BasicHttpBinding(), "");
-endPoint.AddBehavior<TracingBehavior>();
+endPoint.AddBehavior<InspectorBehavior<TracingInspector>>();
 host.Open();
 
 var factory = new DuplexChannelFactory<ISimplePlatformService>(callbackInstance, new WSDualHttpBinding(), new EndpointAddress(SimplePlatformService.BaseAddress));
-factory.Endpoint.AddBehavior<TracingBehavior>();
+factory.Endpoint.AddBehavior<InspectorBehavior<TracingInspector>>();
 var proxy = factory.CreateChannel(callbackInstance);
 ```
 
@@ -47,7 +47,7 @@ When there is not a current DistributedOperationContext during a WCF call a new 
 It is also possible to force a new DistributedOperationContext when it is necessary to run multiple parralel WCF calls with the same TraceId:
 ```csharp
 var channelFactory = new ChannelFactory<ISimpleEdgeService>(new BasicHttpBinding(), new EndpointAddress(SimpleEdgeService.BaseAddress));
-channelFactory.Endpoint.AddBehavior<TracingBehavior>();
+channelFactory.Endpoint.AddBehavior<InspectorBehavior<TracingInspector>>();
 var proxy = channelFactory.CreateChannel();
 
 // All WCF operations and logging statements will have the same TraceId after this initialization

--- a/WCFDistributedTracing/WCF/InspectorBehavior.cs
+++ b/WCFDistributedTracing/WCF/InspectorBehavior.cs
@@ -42,7 +42,9 @@ namespace WCFDistributedTracing.WCF
 
         public void ApplyDispatchBehavior(ServiceDescription serviceDescription, ServiceHostBase serviceHostBase)
         {
-            foreach (ChannelDispatcher channelDispatcherBase in serviceHostBase.ChannelDispatchers)
+            foreach (var channelDispatcherBase1 in serviceHostBase.ChannelDispatchers)
+            {
+                var channelDispatcherBase = (ChannelDispatcher) channelDispatcherBase1;
                 foreach (var eDispatcher in channelDispatcherBase.Endpoints)
                 {
                     eDispatcher.DispatchRuntime.MessageInspectors.AddIfNotExists(_inspector);
@@ -51,6 +53,7 @@ namespace WCFDistributedTracing.WCF
                     foreach (var dispatchOperation in eDispatcher.DispatchRuntime.Operations)
                         dispatchOperation.ParameterInspectors.AddIfNotExists(_inspector);
                 }
+            }
         }
 
         public void ApplyDispatchBehavior(OperationDescription operationDescription, DispatchOperation dispatchOperation)


### PR DESCRIPTION
We forgot to test the situation where a wcf client doesn't send a traceid in the headers. It crashed. Now it creates a new Context and traceid to use in the response(s).